### PR TITLE
chore: add permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
 
   release-please:
     needs: [build]
+    permissions:
+      contents: write # to create release commit (google-github-actions/release-please-action)
+      pull-requests: write # to create release PR (google-github-actions/release-please-action)
+
     runs-on: ubuntu-latest
     steps:
       - uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
- [x] Enable `Allow GitHub Actions to create and approve pull requests` on `jotai-labs` org cc: @dai-shi could you pls help me here?
- [x] Enable `Allow GitHub Actions to create and approve pull requests` on `jotai-devtools` repo