### PR TITLE
fix(utils): pass options through base hooks

### DIFF
--- a/src/utils/useAtomDevtools.ts
+++ b/src/utils/useAtomDevtools.ts
@@ -3,7 +3,7 @@ import { useAtom } from 'jotai/react';
 import type { Atom, WritableAtom } from 'jotai/vanilla';
 import { Message } from './types';
 
-type DevtoolOptions = {
+type DevtoolOptions = Parameters<typeof useAtom>[1] & {
   name?: string;
   enabled?: boolean;
 };
@@ -28,7 +28,7 @@ export function useAtomDevtools<Value, Result>(
     }
   }
 
-  const [value, setValue] = useAtom(anAtom);
+  const [value, setValue] = useAtom(anAtom, options);
 
   const lastValue = useRef(value);
   const isTimeTraveling = useRef(false);

--- a/src/utils/useAtomsDevtools.ts
+++ b/src/utils/useAtomsDevtools.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from 'react';
-import { AnyAtom, AnyAtomValue, AtomsSnapshot, Message } from './types';
+import {
+  AnyAtom,
+  AnyAtomValue,
+  AtomsSnapshot,
+  Message,
+  Options,
+} from './types';
 import { useAtomsSnapshot } from './useAtomsSnapshot';
 import { useGotoAtomsSnapshot } from './useGotoAtomsSnapshot';
 
@@ -21,7 +27,7 @@ const getDevtoolsState = (atomsSnapshot: AtomsSnapshot) => {
   };
 };
 
-type DevtoolsOptions = {
+type DevtoolsOptions = Options & {
   enabled?: boolean;
 };
 
@@ -46,8 +52,8 @@ export function useAtomsDevtools(
   }
 
   // This an exception, we don't usually use utils in themselves!
-  const atomsSnapshot = useAtomsSnapshot();
-  const goToSnapshot = useGotoAtomsSnapshot();
+  const atomsSnapshot = useAtomsSnapshot(options);
+  const goToSnapshot = useGotoAtomsSnapshot(options);
 
   const isTimeTraveling = useRef(false);
   const isRecording = useRef(true);


### PR DESCRIPTION
While working on https://github.com/pmndrs/jotai/pull/1685, I realized some options are missing in devtools utils (hooks).