### PR TITLE
fix(utils): types for /utils entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "sideEffects": false,
   "source": "./src/index.ts",
-  "types": "./dist/index.d.ts",
   "main": "./dist/index.cjs.js",
   "exports": {
     "./package.json": "./package.json",
@@ -17,22 +16,26 @@
         "types": "./dist/index.d.mts",
         "default": "./dist/index.esm.mjs"
       },
-      "default": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.cjs.js"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.cjs.js"
     },
     "./*": {
       "import": {
         "types": "./dist/*.d.mts",
         "default": "./dist/*.esm.mjs"
       },
-      "default": {
-        "types": "./dist/*.d.ts",
-        "default": "./dist/*.cjs.js"
-      }
+      "types": "./dist/*.d.ts",
+      "default": "./dist/*.cjs.js"
     }
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*.d.ts"
+      ]
+    }
+  },
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
     "package.json"


### PR DESCRIPTION
- fix types for `import { useAtomsSnapshot } from 'jotai-devtools/utils`  for when `moduleResolution` is set to `node` for our users
